### PR TITLE
Reintroduce end-to-end specs

### DIFF
--- a/Solutions/Marain.Workflow.Api.Specs/Bindings/WorkflowFunctionsContainerBindings.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/Bindings/WorkflowFunctionsContainerBindings.cs
@@ -52,6 +52,8 @@ namespace Marain.Workflow.Api.Specs.Bindings
 
                     services.AddAzureManagedIdentityBasedTokenSource(msiTokenSourceOptions);
 
+                    Console.WriteLine($"Configuring Tenant Provider Service Client with TenancyServiceBaseUri = '{root["TenancyClient:TenancyServiceBaseUri"]}'");
+
                     services.AddSingleton(new TenancyClientOptions
                     {
                         TenancyServiceBaseUri = new Uri(root["TenancyClient:TenancyServiceBaseUri"]),

--- a/Solutions/Marain.Workflow.Api.Specs/Bindings/WorkflowFunctionsContainerBindings.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/Bindings/WorkflowFunctionsContainerBindings.cs
@@ -60,6 +60,8 @@ namespace Marain.Workflow.Api.Specs.Bindings
                         cosmosConfiguration.RootTenantCosmosConfiguration = new CosmosConfiguration();
                     }
 
+                    cosmosConfiguration.AzureServicesAuthConnectionString = azureServicesAuthConnectionString;
+
                     services.AddTenantCosmosContainerFactory(cosmosConfiguration);
 
                     services.AddTenantedWorkflowEngineFactory();

--- a/Solutions/Marain.Workflow.Api.Specs/EndToEnd/SendTriggerToInstance.feature
+++ b/Solutions/Marain.Workflow.Api.Specs/EndToEnd/SendTriggerToInstance.feature
@@ -1,24 +1,24 @@
-﻿#@perFeatureContainer
-#@useWorkflowMessageProcessingApi
-#@useWorkflowEngineApi
-#@useTransientTenant
-#@useChildObjects
+﻿@perFeatureContainer
+@useWorkflowMessageProcessingApi
+@useWorkflowEngineApi
+@useTransientTenant
+@useChildObjects
 Feature: SendTriggerToInstance
 	In order to tell the workflow engine to carry out actions
 	As an external user of the workflow engine
 	I want to send a trigger to a specific workflow instance
 
-#Scenario: Send a trigger
-#	Given I have added the workflow 'SimpleExpensesWorkflow' to the workflow store with Id 'simple-expenses-workflow'
-#	And The workflow instance store is empty
-#	And I have a dictionary called 'context'
-#	| Key        | Value    |
-#	| Claimant   | J George |
-#	| CostCenter | GD3724   |
-#	And I have started an instance of the workflow 'simple-expenses-workflow' with instance id 'instance' and using context object 'context'
-#	And I have an object of type 'application/vnd.marain.workflows.hosted.trigger' called 'trigger'
-#	| TriggerName |
-#	| Submit      |
-#	When I post the object called 'trigger' to the workflow message processing path '/{tenantId}/marain/workflow/messageprocessing/triggers'
-#	Then I should have received a 202 status code from the HTTP request
-#	And the workflow instance with id 'instance' should be in the state with name 'Waiting for approval' within 180 seconds
+Scenario: Send a trigger
+	Given I have added the workflow 'SimpleExpensesWorkflow' to the workflow store with Id 'simple-expenses-workflow'
+	And The workflow instance store is empty
+	And I have a dictionary called 'context'
+	| Key        | Value    |
+	| Claimant   | J George |
+	| CostCenter | GD3724   |
+	And I have started an instance of the workflow 'simple-expenses-workflow' with instance id 'instance' and using context object 'context'
+	And I have an object of type 'application/vnd.marain.workflows.hosted.trigger' called 'trigger'
+	| TriggerName |
+	| Submit      |
+	When I post the object called 'trigger' to the workflow message processing path '/{tenantId}/marain/workflow/messageprocessing/triggers'
+	Then I should have received a 202 status code from the HTTP request
+	And the workflow instance with id 'instance' should be in the state with name 'Waiting for approval' within 180 seconds

--- a/Solutions/Marain.Workflow.Api.Specs/EndToEnd/SendTriggerToInstance.feature.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/EndToEnd/SendTriggerToInstance.feature.cs
@@ -21,12 +21,22 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("SendTriggerToInstance")]
+    [NUnit.Framework.CategoryAttribute("perFeatureContainer")]
+    [NUnit.Framework.CategoryAttribute("useWorkflowMessageProcessingApi")]
+    [NUnit.Framework.CategoryAttribute("useWorkflowEngineApi")]
+    [NUnit.Framework.CategoryAttribute("useTransientTenant")]
+    [NUnit.Framework.CategoryAttribute("useChildObjects")]
     public partial class SendTriggerToInstanceFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private string[] _featureTags = ((string[])(null));
+        private string[] _featureTags = new string[] {
+                "perFeatureContainer",
+                "useWorkflowMessageProcessingApi",
+                "useWorkflowEngineApi",
+                "useTransientTenant",
+                "useChildObjects"};
         
 #line 1 "SendTriggerToInstance.feature"
 #line hidden
@@ -37,7 +47,12 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
             TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "SendTriggerToInstance", "\tIn order to tell the workflow engine to carry out actions\r\n\tAs an external user " +
                     "of the workflow engine\r\n\tI want to send a trigger to a specific workflow instanc" +
-                    "e", ProgrammingLanguage.CSharp, ((string[])(null)));
+                    "e", ProgrammingLanguage.CSharp, new string[] {
+                        "perFeatureContainer",
+                        "useWorkflowMessageProcessingApi",
+                        "useWorkflowEngineApi",
+                        "useTransientTenant",
+                        "useChildObjects"});
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -73,6 +88,78 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
         public virtual void ScenarioCleanup()
         {
             testRunner.CollectScenarioErrors();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Send a trigger")]
+        public virtual void SendATrigger()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Send a trigger", null, ((string[])(null)));
+#line 11
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 12
+ testRunner.Given("I have added the workflow \'SimpleExpensesWorkflow\' to the workflow store with Id " +
+                        "\'simple-expenses-workflow\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 13
+ testRunner.And("The workflow instance store is empty", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table1 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value"});
+                table1.AddRow(new string[] {
+                            "Claimant",
+                            "J George"});
+                table1.AddRow(new string[] {
+                            "CostCenter",
+                            "GD3724"});
+#line 14
+ testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table1, "And ");
+#line hidden
+#line 18
+ testRunner.And("I have started an instance of the workflow \'simple-expenses-workflow\' with instan" +
+                        "ce id \'instance\' and using context object \'context\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
+                            "TriggerName"});
+                table2.AddRow(new string[] {
+                            "Submit"});
+#line 19
+ testRunner.And("I have an object of type \'application/vnd.marain.workflows.hosted.trigger\' called" +
+                        " \'trigger\'", ((string)(null)), table2, "And ");
+#line hidden
+#line 22
+ testRunner.When("I post the object called \'trigger\' to the workflow message processing path \'/{ten" +
+                        "antId}/marain/workflow/messageprocessing/triggers\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 23
+ testRunner.Then("I should have received a 202 status code from the HTTP request", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 24
+ testRunner.And("the workflow instance with id \'instance\' should be in the state with name \'Waitin" +
+                        "g for approval\' within 180 seconds", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
         }
     }
 }

--- a/Solutions/Marain.Workflow.Api.Specs/EndToEnd/StartNewInstance.feature
+++ b/Solutions/Marain.Workflow.Api.Specs/EndToEnd/StartNewInstance.feature
@@ -1,25 +1,25 @@
-﻿#@perFeatureContainer
-#@useWorkflowMessageProcessingApi
-#@useWorkflowEngineApi
-#@useTransientTenant
-#@useChildObjects
+﻿@perFeatureContainer
+@useWorkflowMessageProcessingApi
+@useWorkflowEngineApi
+@useTransientTenant
+@useChildObjects
 Feature: StartNewInstance
 	In order manage a new thing through a workflow
 	As an external user of the workflow engine
 	I want to be able to start a new instance of a workflow
 
-#Scenario: Start a new instance with a specified instance id
-#	Given I have added the workflow 'SimpleExpensesWorkflow' to the workflow store with Id 'simple-expenses-workflow'
-#	And The workflow instance store is empty
-#	And I have a dictionary called 'context'
-#	| Key        | Value    |
-#	| Claimant   | J George |
-#	| CostCenter | GD3724   |
-#	And I have an object of type 'application/vnd.marain.workflows.hosted.startworkflowinstancerequest' called 'request'
-#	| WorkflowId               | WorkflowInstanceId | Context   |
-#	| simple-expenses-workflow | instance           | {context} |
-#	When I post the object called 'request' to the workflow message processing path '/{tenantId}/marain/workflow/messageprocessing/startnewworkflowinstancerequests'
-#	Then I should have received a 202 status code from the HTTP request
-#	And there should be a workflow instance with the id 'instance' in the workflow instance store within 300 seconds
-#	And the workflow instance with id 'instance' should be an instance of the workflow with id 'simple-expenses-workflow'
-#	And the workflow instance with id 'instance' should have a context dictionary that matches 'context'
+Scenario: Start a new instance with a specified instance id
+	Given I have added the workflow 'SimpleExpensesWorkflow' to the workflow store with Id 'simple-expenses-workflow'
+	And The workflow instance store is empty
+	And I have a dictionary called 'context'
+	| Key        | Value    |
+	| Claimant   | J George |
+	| CostCenter | GD3724   |
+	And I have an object of type 'application/vnd.marain.workflows.hosted.startworkflowinstancerequest' called 'request'
+	| WorkflowId               | WorkflowInstanceId | Context   |
+	| simple-expenses-workflow | instance           | {context} |
+	When I post the object called 'request' to the workflow message processing path '/{tenantId}/marain/workflow/messageprocessing/startnewworkflowinstancerequests'
+	Then I should have received a 202 status code from the HTTP request
+	And there should be a workflow instance with the id 'instance' in the workflow instance store within 300 seconds
+	And the workflow instance with id 'instance' should be an instance of the workflow with id 'simple-expenses-workflow'
+	And the workflow instance with id 'instance' should have a context dictionary that matches 'context'

--- a/Solutions/Marain.Workflow.Api.Specs/EndToEnd/StartNewInstance.feature.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/EndToEnd/StartNewInstance.feature.cs
@@ -21,12 +21,22 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
     [NUnit.Framework.DescriptionAttribute("StartNewInstance")]
+    [NUnit.Framework.CategoryAttribute("perFeatureContainer")]
+    [NUnit.Framework.CategoryAttribute("useWorkflowMessageProcessingApi")]
+    [NUnit.Framework.CategoryAttribute("useWorkflowEngineApi")]
+    [NUnit.Framework.CategoryAttribute("useTransientTenant")]
+    [NUnit.Framework.CategoryAttribute("useChildObjects")]
     public partial class StartNewInstanceFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
         
-        private string[] _featureTags = ((string[])(null));
+        private string[] _featureTags = new string[] {
+                "perFeatureContainer",
+                "useWorkflowMessageProcessingApi",
+                "useWorkflowEngineApi",
+                "useTransientTenant",
+                "useChildObjects"};
         
 #line 1 "StartNewInstance.feature"
 #line hidden
@@ -36,7 +46,12 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
             TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "StartNewInstance", "\tIn order manage a new thing through a workflow\r\n\tAs an external user of the work" +
-                    "flow engine\r\n\tI want to be able to start a new instance of a workflow", ProgrammingLanguage.CSharp, ((string[])(null)));
+                    "flow engine\r\n\tI want to be able to start a new instance of a workflow", ProgrammingLanguage.CSharp, new string[] {
+                        "perFeatureContainer",
+                        "useWorkflowMessageProcessingApi",
+                        "useWorkflowEngineApi",
+                        "useTransientTenant",
+                        "useChildObjects"});
             testRunner.OnFeatureStart(featureInfo);
         }
         
@@ -72,6 +87,86 @@ namespace Marain.Workflows.Api.Specs.EndToEnd
         public virtual void ScenarioCleanup()
         {
             testRunner.CollectScenarioErrors();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Start a new instance with a specified instance id")]
+        public virtual void StartANewInstanceWithASpecifiedInstanceId()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Start a new instance with a specified instance id", null, ((string[])(null)));
+#line 11
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 12
+ testRunner.Given("I have added the workflow \'SimpleExpensesWorkflow\' to the workflow store with Id " +
+                        "\'simple-expenses-workflow\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 13
+ testRunner.And("The workflow instance store is empty", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value"});
+                table3.AddRow(new string[] {
+                            "Claimant",
+                            "J George"});
+                table3.AddRow(new string[] {
+                            "CostCenter",
+                            "GD3724"});
+#line 14
+ testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table3, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
+                            "WorkflowId",
+                            "WorkflowInstanceId",
+                            "Context"});
+                table4.AddRow(new string[] {
+                            "simple-expenses-workflow",
+                            "instance",
+                            "{context}"});
+#line 18
+ testRunner.And("I have an object of type \'application/vnd.marain.workflows.hosted.startworkflowin" +
+                        "stancerequest\' called \'request\'", ((string)(null)), table4, "And ");
+#line hidden
+#line 21
+ testRunner.When("I post the object called \'request\' to the workflow message processing path \'/{ten" +
+                        "antId}/marain/workflow/messageprocessing/startnewworkflowinstancerequests\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 22
+ testRunner.Then("I should have received a 202 status code from the HTTP request", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 23
+ testRunner.And("there should be a workflow instance with the id \'instance\' in the workflow instan" +
+                        "ce store within 300 seconds", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 24
+ testRunner.And("the workflow instance with id \'instance\' should be an instance of the workflow wi" +
+                        "th id \'simple-expenses-workflow\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 25
+ testRunner.And("the workflow instance with id \'instance\' should have a context dictionary that ma" +
+                        "tches \'context\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
         }
     }
 }

--- a/Solutions/Marain.Workflow.Api.Specs/EngineHost/SendTriggerToInstance.feature.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/EngineHost/SendTriggerToInstance.feature.cs
@@ -120,29 +120,29 @@ this.ScenarioInitialize(scenarioInfo);
 #line 12
  testRunner.And("The workflow instance store is empty", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table1 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
                             "Key",
                             "Value"});
-                table1.AddRow(new string[] {
+                table5.AddRow(new string[] {
                             "Claimant",
                             "J George"});
-                table1.AddRow(new string[] {
+                table5.AddRow(new string[] {
                             "CostCenter",
                             "GD3724"});
 #line 13
- testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table1, "And ");
+ testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table5, "And ");
 #line hidden
 #line 17
  testRunner.And("I have started an instance of the workflow \'simple-expenses-workflow\' with instan" +
                         "ce id \'instance\' and using context object \'context\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
                             "TriggerName"});
-                table2.AddRow(new string[] {
+                table6.AddRow(new string[] {
                             "Submit"});
 #line 18
  testRunner.And("I have an object of type \'application/vnd.marain.workflows.hosted.trigger\' called" +
-                        " \'trigger\'", ((string)(null)), table2, "And ");
+                        " \'trigger\'", ((string)(null)), table6, "And ");
 #line hidden
 #line 21
  testRunner.When("I post the object called \'trigger\' to the workflow engine path \'/{tenantId}/marai" +
@@ -185,13 +185,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-                TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
                             "TriggerName"});
-                table3.AddRow(new string[] {
+                table7.AddRow(new string[] {
                             "Submit"});
 #line 26
  testRunner.Given("I have an object of type \'application/vnd.marain.workflows.hosted.trigger\' called" +
-                        " \'trigger\'", ((string)(null)), table3, "Given ");
+                        " \'trigger\'", ((string)(null)), table7, "Given ");
 #line hidden
 #line 29
  testRunner.When("I post the object called \'trigger\' to the workflow engine path \'/{tenantId}/marai" +

--- a/Solutions/Marain.Workflow.Api.Specs/EngineHost/StartNewInstance.feature.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/EngineHost/StartNewInstance.feature.cs
@@ -119,29 +119,29 @@ this.ScenarioInitialize(scenarioInfo);
 #line 12
  testRunner.And("The workflow instance store is empty", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
                             "Key",
                             "Value"});
-                table4.AddRow(new string[] {
+                table8.AddRow(new string[] {
                             "Claimant",
                             "J George"});
-                table4.AddRow(new string[] {
+                table8.AddRow(new string[] {
                             "CostCenter",
                             "GD3724"});
 #line 13
- testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table4, "And ");
+ testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table8, "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
                             "WorkflowId",
                             "WorkflowInstanceId",
                             "Context"});
-                table5.AddRow(new string[] {
+                table9.AddRow(new string[] {
                             "simple-expenses-workflow",
                             "instance",
                             "{context}"});
 #line 17
  testRunner.And("I have an object of type \'application/vnd.marain.workflows.hosted.startworkflowin" +
-                        "stancerequest\' called \'request\'", ((string)(null)), table5, "And ");
+                        "stancerequest\' called \'request\'", ((string)(null)), table9, "And ");
 #line hidden
 #line 20
  testRunner.When("I post the object called \'request\' to the workflow engine path \'/{tenantId}/marai" +
@@ -199,27 +199,27 @@ this.ScenarioInitialize(scenarioInfo);
 #line 28
  testRunner.And("The workflow instance store is empty", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
                             "Key",
                             "Value"});
-                table6.AddRow(new string[] {
+                table10.AddRow(new string[] {
                             "Claimant",
                             "J George"});
-                table6.AddRow(new string[] {
+                table10.AddRow(new string[] {
                             "CostCenter",
                             "GD3724"});
 #line 29
- testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table6, "And ");
+ testRunner.And("I have a dictionary called \'context\'", ((string)(null)), table10, "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
                             "WorkflowId",
                             "Context"});
-                table7.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "simple-expenses-workflow",
                             "{context}"});
 #line 33
  testRunner.And("I have an object of type \'application/vnd.marain.workflows.hosted.startworkflowin" +
-                        "stancerequest\' called \'request\'", ((string)(null)), table7, "And ");
+                        "stancerequest\' called \'request\'", ((string)(null)), table11, "And ");
 #line hidden
 #line 36
  testRunner.When("I post the object called \'request\' to the workflow engine path \'/{tenantId}/marai" +
@@ -261,13 +261,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-                TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
                             "WorkflowId"});
-                table8.AddRow(new string[] {
+                table12.AddRow(new string[] {
                             "4629f9f3-a706-4901-a215-df8313376b52"});
 #line 41
  testRunner.Given("I have an object of type \'application/vnd.marain.workflows.hosted.startworkflowin" +
-                        "stancerequest\' called \'request\'", ((string)(null)), table8, "Given ");
+                        "stancerequest\' called \'request\'", ((string)(null)), table12, "Given ");
 #line hidden
 #line 44
  testRunner.When("I post the object called \'request\' to the workflow engine path \'/{tenantId}/marai" +

--- a/Solutions/Marain.Workflow.Api.Specs/Marain.Workflow.Api.Specs.csproj
+++ b/Solutions/Marain.Workflow.Api.Specs/Marain.Workflow.Api.Specs.csproj
@@ -16,7 +16,7 @@
   
   <ItemGroup>
     <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.7.0-preview.6" />
-    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="0.22.0" />
+    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="0.3.0-preview.8" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">

--- a/Solutions/Marain.Workflow.Api.Specs/local.settings.template.json
+++ b/Solutions/Marain.Workflow.Api.Specs/local.settings.template.json
@@ -1,6 +1,11 @@
 {
   "LeasingStorageAccountConnectionString": "UseDevelopmentStorage=true",
 
+  // If using TransientTenantBindings in your spec, you should provide a parent for the tenants that are created and deleted
+  // in each test. Ideally this will be a sub-tenant of your organisation's main tenant that's reserved to parent for test
+  // tenants.
+  "TransientTenantBindings:ParentTenantId": "032d3c5dab96634fa4c5fffcd1b793182ba8fa6de57ad848993a193039de7aa5",
+
   // If running with a local tenancy service, point TenancyClient:TenancyServiceBaseUri at the localhost address for that
   // and set the ResourceIdForMsiAuthentication to an empty string.
   "TenancyClient:TenancyServiceBaseUri": "https://mardevtenancy.azurewebsites.net/",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
           Write-Host "##vso[task.setvariable variable=TenantSqlConnectionFactoryOptions__RootTenantSqlConfiguration__ConnectionStringSecretName]$Env:ENDJIN_SQLDBCONNECTIONSTRINGSECRETNAME"
           Write-Host "##vso[task.setvariable variable=TenantSqlConnectionFactoryOptions__RootTenantSqlConfiguration__KeyVaultName]$Env:ENDJIN_KEYVAULTNAME"
           Write-Host "##vso[task.setvariable variable=LeasingStorageAccountConnectionString]$Env:ENDJIN_AZURESTORAGECONNECTIONSTRING"
+          Write-Host "##vso[task.setvariable variable=TransientTenantBindings__ParentTenantId]$Env:ENDJIN_INTEGRATIONTESTPARENTTENANTID"
         displayName: 'Set Custom Environment Variables'
         env:
           ENDJIN_AZURESERVICESAUTHCONNECTIONSTRING: $(Endjin_AzureServicesAuthConnectionString)
@@ -51,6 +52,7 @@ jobs:
           ENDJIN_KEYVAULTNAME: $(Endjin_KeyVaultName)
           ENDJIN_SQLDBDATABASE: $(Endjin_SqlDbDatabase)
           ENDJIN_SQLDBCONNECTIONSTRINGSECRETNAME: $(Endjin_SqlDbConnectionStringSecretName)
+          ENDJIN_INTEGRATIONTESTPARENTTENANTID: $(Endjin_IntegrationTestParentTenantId)
       - task: Npm@1
         displayName: 'Install Latest Azure Functions V3 Runtime'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,6 @@ jobs:
           Write-Host "##vso[task.setvariable variable=TenancyClient__ResourceIdForMsiAuthentication]$Env:ENDJIN_MARAINTENANCYRESOURCEIDFORMSIAUTHENTICATION"
           Write-Host "##vso[task.setvariable variable=Operations__ControlServiceBaseUrl]$Env:ENDJIN_MARAINOPERATIONSCONTROLBASEURL"
           Write-Host "##vso[task.setvariable variable=Operations__ResourceIdForMsiAuthentication]$Env:ENDJIN_MARAINOPERATIONSCONTROLRESOURCEID"
-          Write-Host "##vso[task.setvariable variable=TenantCloudBlobContainerFactoryOptions__RootTenantBlobStorageConfiguration__AccountName]$Env:ENDJIN_MARAINTENANCYSTORAGECONNECTIONSTRING"
           Write-Host "##vso[task.setvariable variable=TenantCosmosContainerFactoryOptions__RootTenantCosmosConfiguration__AccountUri]$Env:ENDJIN_COSMOSDBACCOUNTURI"
           Write-Host "##vso[task.setvariable variable=TenantCosmosContainerFactoryOptions__RootTenantCosmosConfiguration__AccountKeySecretName]$Env:ENDJIN_COSMOSDBKEYSECRETNAME"
           Write-Host "##vso[task.setvariable variable=TenantCosmosContainerFactoryOptions__RootTenantCosmosConfiguration__KeyVaultName]$Env:ENDJIN_KEYVAULTNAME"


### PR DESCRIPTION
Now that there is a Marain.Instance deployment in the Endjin Azure subcription, we can re-introduce the end to end test scripts that were previously disabled due to their dependency on Marain.Operations and Marain.Tenancy.

This PR includes re-enabling the tests and some tweaks to the transient tenant bindings so that transient tenants are created under a well-known parent tenant rather than the root. This allows us to parent all transient tenants with an "integration test" tenant, allowing for easy clean up should they be left around as a result of errors during test execution.

It also changes the API specs project to use the Tenancy API when creating the transient tenants, rather than pushing new tenants directly into storage.