### PR TITLE
Change the two API client projects to target NET Standard 2.0

### DIFF
--- a/Solutions/Marain.Workflow.Api.Client/Marain.Workflow.Api.Client.csproj
+++ b/Solutions/Marain.Workflow.Api.Client/Marain.Workflow.Api.Client.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Solutions/Marain.Workflow.Api.EngineHost.Client/Marain.Workflow.Api.EngineHost.Client.csproj
+++ b/Solutions/Marain.Workflow.Api.EngineHost.Client/Marain.Workflow.Api.EngineHost.Client.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace />
     <DocumentationFile>$(OutputPath)$(TargetFramework.ToLowerInvariant())\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
These projects were recently changed to .NET Core 3.1 along with all of the others in the solution. In fact they should have been left as .NET Standard 2.0 to allow maximum flexibility in usage by consumers.

Resolves #124 