### PR TITLE
Fix errors where invocation of external services as part of a workflow instance creation throws errors

### DIFF
--- a/Solutions/Marain.Workflow.Abstractions/Marain/Workflows/InvokeExternalServiceAction.cs
+++ b/Solutions/Marain.Workflow.Abstractions/Marain/Workflows/InvokeExternalServiceAction.cs
@@ -157,7 +157,7 @@ namespace Marain.Workflows
                 "Initialising request for workflow instance '{workflowInstanceId} to external URL '{externalUrl}' resulting from trigger '{triggerId}'",
                 instance.Id,
                 this.ExternalUrl,
-                trigger.Id);
+                trigger?.Id ?? "{no trigger}");
 
             var request = new HttpRequestMessage(HttpMethod.Post, this.ExternalUrl);
 
@@ -210,7 +210,7 @@ namespace Marain.Workflows
                     this.ContentType,
                     this.Id,
                     instance.Id,
-                    trigger.Id,
+                    trigger?.Id ?? "{no trigger}",
                     httpResponse.StatusCode,
                     httpResponse.ReasonPhrase);
             }

--- a/Solutions/Marain.Workflow.Abstractions/Marain/Workflows/InvokeExternalServiceCondition.cs
+++ b/Solutions/Marain.Workflow.Abstractions/Marain/Workflows/InvokeExternalServiceCondition.cs
@@ -162,7 +162,7 @@ namespace Marain.Workflows
                     this.ContentType,
                     this.Id,
                     instance.Id,
-                    trigger.Id,
+                    trigger?.Id ?? "{no trigger}",
                     response.StatusCode,
                     response.ReasonPhrase);
             }


### PR DESCRIPTION
The code in `InvokeExternalServiceAction` and `InvokeExternalServiceCondition` uses the trigger as part of logging. When an external service is being invoked as part of workflow instance creation there is no trigger, and this results in a `NullReferenceException`. 

