### PR TITLE
Updated dependencies

### DIFF
--- a/Solutions/Marain.Workflow.Abstractions/Marain.Workflow.Abstractions.csproj
+++ b/Solutions/Marain.Workflow.Abstractions/Marain.Workflow.Abstractions.csproj
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling" Version="0.14.0" />
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.11.0" />
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="0.2.0-preview.15" />
-    <PackageReference Include="Corvus.Leasing.Abstractions" Version="0.5.0-preview.5" />
+    <PackageReference Include="Corvus.ContentHandling" Version="1.0.0" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="1.0.0" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
+    <PackageReference Include="Corvus.Leasing.Abstractions" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Api.Client/Marain.Workflow.Api.Client.csproj
+++ b/Solutions/Marain.Workflow.Api.Client/Marain.Workflow.Api.Client.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.11.0" />
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="0.2.0-preview.15" />
+    <PackageReference Include="Corvus.Extensions" Version="1.0.0" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="1.0.0" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Api.EngineHost.Client/Marain.Workflow.Api.EngineHost.Client.csproj
+++ b/Solutions/Marain.Workflow.Api.EngineHost.Client/Marain.Workflow.Api.EngineHost.Client.csproj
@@ -33,9 +33,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.11.0" />
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="0.2.0-preview.15" />
+    <PackageReference Include="Corvus.Extensions" Version="1.0.0" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="1.0.0" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Api.MessageProcessingHost/Marain.Workflow.Api.MessageProcessingHost.csproj
+++ b/Solutions/Marain.Workflow.Api.MessageProcessingHost/Marain.Workflow.Api.MessageProcessingHost.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
-    <PackageReference Include="Marain.Services.Tenancy" Version="0.1.0-preview.25" />
+    <PackageReference Include="Marain.Services.Tenancy" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,9 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Marain.Operations.ControlClient" Version="0.9.0-preview.14" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.8.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.2.1" />
+    <PackageReference Include="Marain.Operations.ControlClient" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.13.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Marain.Workflow.Abstractions\Marain.Workflow.Abstractions.csproj" />

--- a/Solutions/Marain.Workflow.Api.MessageProcessingHost/Marain/Workflows/Api/MessageProcessingHost/Startup.cs
+++ b/Solutions/Marain.Workflow.Api.MessageProcessingHost/Marain/Workflows/Api/MessageProcessingHost/Startup.cs
@@ -16,7 +16,6 @@ namespace Marain.Workflows.Api.MessageProcessingHost.Shared
     using Microsoft.Azure.WebJobs.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Startup code for the Function.
@@ -28,14 +27,27 @@ namespace Marain.Workflows.Api.MessageProcessingHost.Shared
         {
             IServiceCollection services = builder.Services;
 
-            IConfigurationRoot root = Configure(services);
-
             services.AddApplicationInsightsInstrumentationTelemetry();
             services.AddLogging();
 
-            var uri = new Uri(root["Operations:ControlServiceBaseUrl"]);
-            string resourceId = root["Operations:ResourceIdForMsiAuthentication"];
-            services.AddOperationsControlClient(uri, resourceId);
+            services.AddOperationsControlClient(
+                sp =>
+                {
+                    IConfiguration config = sp.GetRequiredService<IConfiguration>();
+
+                    string baseUrl = config["Operations:ControlServiceBaseUrl"];
+
+                    if (string.IsNullOrEmpty(baseUrl))
+                    {
+                        throw new InvalidOperationException("Cannot find a configuration value for 'Operations:ControlServiceBaseUrl'. Please add this configuration value and retry.");
+                    }
+
+                    return new MarainOperationsControlClientOptions
+                    {
+                        OperationsControlServiceBaseUri = new Uri(baseUrl),
+                        ResourceIdForMsiAuthentication = config["Operations:ResourceIdForMsiAuthentication"],
+                    };
+                });
 
             services.AddMarainWorkflowEngineClient(sp =>
             {
@@ -80,19 +92,6 @@ namespace Marain.Workflows.Api.MessageProcessingHost.Shared
             services.AddSingleton<IOpenApiService, MessageIngestionService>();
 
             return services;
-        }
-
-        private static IConfigurationRoot Configure(IServiceCollection services)
-        {
-            // TODO: Get rid of this and replace any of our code that depends on it with custom configuration sections.
-            // https://github.com/marain-dotnet/Marain.Workflow/issues/45
-            IConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
-                .AddEnvironmentVariables()
-                .AddJsonFile("local.settings.json", optional: true, reloadOnChange: true);
-
-            IConfigurationRoot root = configurationBuilder.Build();
-            services.AddSingleton(root);
-            return root;
         }
     }
 }

--- a/Solutions/Marain.Workflow.Api.Services.AspNetCore/Marain.Workflow.Api.Services.AspNetCore.csproj
+++ b/Solutions/Marain.Workflow.Api.Services.AspNetCore/Marain.Workflow.Api.Services.AspNetCore.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Leasing.Azure" Version="0.5.0-preview.5" />
+    <PackageReference Include="Corvus.Leasing.Azure" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="0.3.0-preview.34" />
-    <PackageReference Include="Menes.Hosting.AspNetCore" Version="0.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
+    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.0.2" />
+    <PackageReference Include="Menes.Hosting.AspNetCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Workflow.Api.Services/Marain.Workflow.Api.Services.csproj
+++ b/Solutions/Marain.Workflow.Api.Services/Marain.Workflow.Api.Services.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Operations.ControlClient" Version="0.9.0-preview.14" />
-    <PackageReference Include="Menes.Abstractions" Version="0.11.0" />
-    <PackageReference Include="Marain.Services.Tenancy" Version="0.1.0-preview.25" />
+    <PackageReference Include="Marain.Operations.ControlClient" Version="1.0.1" />
+    <PackageReference Include="Menes.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Marain.Services.Tenancy" Version="1.1.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Solutions/Marain.Workflow.Api.Specs/Marain.Workflow.Api.Specs.csproj
+++ b/Solutions/Marain.Workflow.Api.Specs/Marain.Workflow.Api.Specs.csproj
@@ -18,14 +18,14 @@
   <ItemGroup>
     <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow" Version="1.0.2" />
     <PackageReference Include="Corvus.Testing.SpecFlow" Version="1.0.2" />
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="0.1.0-preview.25" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="1.1.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Workflow.Api.Specs/Steps/WorkflowSteps.cs
+++ b/Solutions/Marain.Workflow.Api.Specs/Steps/WorkflowSteps.cs
@@ -166,7 +166,7 @@ namespace Marain.Workflows.Api.Specs.Steps
                 () => this.GetWorkflowInstance(instanceId, false),
                 tokenSource.Token,
                 new Linear(TimeSpan.FromSeconds(1), int.MaxValue),
-                new AnyException(),
+                new AnyExceptionPolicy(),
                 false).ConfigureAwait(false);
         }
 
@@ -189,7 +189,7 @@ namespace Marain.Workflows.Api.Specs.Steps
                 () => this.VerifyWorkflowInstanceState(instanceId, expectedStateName, false),
                 tokenSource.Token,
                 new Linear(TimeSpan.FromSeconds(1), int.MaxValue),
-                new AnyException(),
+                new AnyExceptionPolicy(),
                 false).ConfigureAwait(false);
         }
 

--- a/Solutions/Marain.Workflow.Specs/Bindings/SqlHelpers.cs
+++ b/Solutions/Marain.Workflow.Specs/Bindings/SqlHelpers.cs
@@ -1,7 +1,6 @@
 ﻿namespace Marain.Workflows.Specs.Bindings
 {
-    using System;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using Microsoft.SqlServer.Dac;
     using Microsoft.SqlServer.Management.Common;
     using Microsoft.SqlServer.Management.Smo;

--- a/Solutions/Marain.Workflow.Specs/Marain.Workflow.Specs.csproj
+++ b/Solutions/Marain.Workflow.Specs/Marain.Workflow.Specs.csproj
@@ -20,34 +20,34 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="0.25.0" />
-    <PackageReference Include="Corvus.Leasing.InMemory" Version="0.5.0-preview.5" />
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="0.2.0-preview.15" />
-    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="0.25.0" />
+    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="1.0.2" />
+    <PackageReference Include="Corvus.Leasing.InMemory" Version="1.0.0" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
+    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="1.0.2" />
     <PackageReference Include="Corvus.Testing.SpecFlow" Version="1.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4769.1" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
+    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4897.1" />
+    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.41011.9" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SpecFlow.NUnit" Version="3.4.8" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.4.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="0.1.0-preview.25" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Workflow.Storage.AzureCosmos/Marain.Workflow.Storage.AzureCosmos.csproj
+++ b/Solutions/Marain.Workflow.Storage.AzureCosmos/Marain.Workflow.Storage.AzureCosmos.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="0.25.0" />
-    <PackageReference Include="Corvus.Extensions.CosmosClient" Version="0.6.0" />
+    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="1.0.2" />
+    <PackageReference Include="Corvus.Extensions.CosmosClient" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Storage.AzureCosmos/Marain/Workflows/Storage/CosmosWorkflowInstanceStore.cs
+++ b/Solutions/Marain.Workflow.Storage.AzureCosmos/Marain/Workflows/Storage/CosmosWorkflowInstanceStore.cs
@@ -145,7 +145,7 @@ namespace Marain.Workflows.Storage
         /// The list of subjects/.
         /// </param>
         /// <returns>
-        /// A <see cref="string" /> containing the WHERE clause and a <see cref="SqlParameterCollection" /> containing
+        /// A <see cref="string" /> containing the WHERE clause and a List containing
         /// the parameters it should be supplied with.
         /// </returns>
         private static (string, List<(string, string)>) GetSubjectClause(IEnumerable<string> subjects)

--- a/Solutions/Marain.Workflow.Storage.AzureStorage/Marain.Workflow.Storage.AzureStorage.csproj
+++ b/Solutions/Marain.Workflow.Storage.AzureStorage/Marain.Workflow.Storage.AzureStorage.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="0.25.0" />
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Storage.Sql/Marain.Workflow.Storage.Sql.csproj
+++ b/Solutions/Marain.Workflow.Storage.Sql/Marain.Workflow.Storage.Sql.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Workflow.Tenancy.Abstractions/Marain.Workflow.Tenancy.Abstractions.csproj
+++ b/Solutions/Marain.Workflow.Tenancy.Abstractions/Marain.Workflow.Tenancy.Abstractions.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="0.25.0" />
+    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="1.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Tenancy.AzureCosmos/Marain.Workflow.Tenancy.AzureCosmos.csproj
+++ b/Solutions/Marain.Workflow.Tenancy.AzureCosmos/Marain.Workflow.Tenancy.AzureCosmos.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="0.25.0" />
+    <PackageReference Include="Corvus.Azure.Cosmos.Tenancy" Version="1.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Workflow.Tenancy.Sql/Marain.Workflow.Tenancy.Sql.csproj
+++ b/Solutions/Marain.Workflow.Tenancy.Sql/Marain.Workflow.Tenancy.Sql.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Sql.Tenancy" Version="0.25.0" />
+    <PackageReference Include="Corvus.Sql.Tenancy" Version="1.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Current release builds are not generating all packages because some projects have dependencies on pre-release versions of packages. To fix this, we need to ensure all dependencies are on released versions. This PR brings as many dependencies up to date as possible.